### PR TITLE
Add PricingTiers component and cyberpunk image slider

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,40 +8,40 @@ const ScorpiusCore = dynamic(() => import("@/components/ScorpiusCore"), {
 
 export default function Home() {
   return (
-    <main
-      className="relative w-screen h-[1000vh] bg-black"
-      id="scroll-container"
-    >
-      {/* Starfield background */}
-      <div className="fixed inset-0 z-0">
-        <div className="absolute inset-0 bg-black">
-          {/* Generate random stars */}
-          {Array.from({ length: 200 }).map((_, i) => (
-            <div
-              key={i}
-              className="absolute bg-white rounded-full opacity-70"
-              style={{
-                left: `${Math.random() * 100}%`,
-                top: `${Math.random() * 100}%`,
-                width: `${Math.random() * 2 + 1}px`,
-                height: `${Math.random() * 2 + 1}px`,
-                animationDelay: `${Math.random() * 3}s`,
-                animation: `twinkle ${2 + Math.random() * 3}s infinite ease-in-out alternate`,
-              }}
-            />
-          ))}
+    <>
+      <main
+        className="relative w-screen h-[1000vh] bg-black"
+        id="scroll-container"
+      >
+        {/* Starfield background */}
+        <div className="fixed inset-0 z-0">
+          <div className="absolute inset-0 bg-black">
+            {/* Generate random stars */}
+            {Array.from({ length: 200 }).map((_, i) => (
+              <div
+                key={i}
+                className="absolute bg-white rounded-full opacity-70"
+                style={{
+                  left: `${Math.random() * 100}%`,
+                  top: `${Math.random() * 100}%`,
+                  width: `${Math.random() * 2 + 1}px`,
+                  height: `${Math.random() * 2 + 1}px`,
+                  animationDelay: `${Math.random() * 3}s`,
+                  animation: `twinkle ${2 + Math.random() * 3}s infinite ease-in-out alternate`,
+                }}
+              />
+            ))}
+          </div>
         </div>
-      </div>
 
-      <div className="sticky top-0 left-0 w-screen h-screen pointer-events-none z-10">
-        <ScorpiusCore />
-      </div>
-      <ScrollUIOverlay />
+        <div className="sticky top-0 left-0 w-screen h-screen pointer-events-none z-10">
+          <ScorpiusCore />
+        </div>
+        <ScrollUIOverlay />
+      </main>
 
-      {/* Pricing section at the end */}
-      <div className="relative z-20">
-        <PricingTiers />
-      </div>
-    </main>
+      {/* Pricing section at the very end */}
+      <PricingTiers />
+    </>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import dynamic from "next/dynamic";
 import ScrollUIOverlay from "@/components/ScrollUIOverlay";
+import PricingTiers from "@/components/PricingTiers";
 
 const ScorpiusCore = dynamic(() => import("@/components/ScorpiusCore"), {
   ssr: false,
@@ -36,6 +37,11 @@ export default function Home() {
         <ScorpiusCore />
       </div>
       <ScrollUIOverlay />
+
+      {/* Pricing section at the end */}
+      <div className="relative z-20">
+        <PricingTiers />
+      </div>
     </main>
   );
 }

--- a/src/components/ScrollUIOverlay.tsx
+++ b/src/components/ScrollUIOverlay.tsx
@@ -369,7 +369,7 @@ export default function ScrollUIOverlay() {
 
               {/* Cyberpunk Image Slider for Enterprise Command */}
               {sec.cyberpunkSlider && isActive && (
-                <div className="mb-6 -mx-8 -my-8">
+                <div className="mb-6">
                   <CyberpunkImageSlider />
                 </div>
               )}

--- a/src/components/ScrollUIOverlay.tsx
+++ b/src/components/ScrollUIOverlay.tsx
@@ -381,7 +381,9 @@ export default function ScrollUIOverlay() {
               {/* Cyberpunk Image Slider for Enterprise Command */}
               {sec.cyberpunkSlider && isActive && (
                 <div className="fixed inset-0 z-30 flex items-center justify-center pointer-events-none">
-                  <CyberpunkImageSlider />
+                  <div className="bg-red-500 text-white p-8 text-2xl">
+                    CYBERPUNK SLIDER DETECTED - SECTION ACTIVE
+                  </div>
                 </div>
               )}
 

--- a/src/components/ScrollUIOverlay.tsx
+++ b/src/components/ScrollUIOverlay.tsx
@@ -1,6 +1,7 @@
 "use client";
 import AnimatedSection from "./AnimatedSection";
 import { useScrollSync } from "./useScrollSync";
+import { CyberpunkImageSlider } from "./ui/cyberpunk-image-slider";
 
 const sections = [
   {
@@ -26,57 +27,7 @@ const sections = [
     subtitle: "Total Control. Infinite Insight.",
     desc: "Executive dashboards, compliance, and instant incident response. All at your fingertips.",
     align: "center",
-    carousel: true,
-    carouselImages: [
-      {
-        title: "Executive Dashboard",
-        desc: "Real-time threat intelligence overview",
-        image:
-          "https://images.unsplash.com/photo-1551288049-bebda4e38f71?w=800&h=600&fit=crop&crop=center",
-      },
-      {
-        title: "Threat Map",
-        desc: "Global attack visualization",
-        image:
-          "https://images.unsplash.com/photo-1558494949-ef010cbdcc31?w=800&h=600&fit=crop&crop=center",
-      },
-      {
-        title: "Analytics Hub",
-        desc: "Advanced security metrics",
-        image:
-          "https://images.unsplash.com/photo-1460925895917-afdab827c52f?w=800&h=600&fit=crop&crop=center",
-      },
-      {
-        title: "Compliance Center",
-        desc: "Regulatory monitoring",
-        image:
-          "https://images.unsplash.com/photo-1454165804606-c3d57bc86b40?w=800&h=600&fit=crop&crop=center",
-      },
-      {
-        title: "Incident Response",
-        desc: "Emergency action protocols",
-        image:
-          "https://images.unsplash.com/photo-1516321318423-f06f85e504b3?w=800&h=600&fit=crop&crop=center",
-      },
-      {
-        title: "Network Monitor",
-        desc: "Infrastructure surveillance",
-        image:
-          "https://images.unsplash.com/photo-1518186285589-2f7649de83e0?w=800&h=600&fit=crop&crop=center",
-      },
-      {
-        title: "Alert System",
-        desc: "Priority notification center",
-        image:
-          "https://images.unsplash.com/photo-1563013544-824ae1b704d3?w=800&h=600&fit=crop&crop=center",
-      },
-      {
-        title: "Command Console",
-        desc: "Central control interface",
-        image:
-          "https://images.unsplash.com/photo-1551033406-611cf9a28f67?w=800&h=600&fit=crop&crop=center",
-      },
-    ],
+    cyberpunkSlider: true,
   },
   {
     title: "Under-the-Hood Firepower",

--- a/src/components/ScrollUIOverlay.tsx
+++ b/src/components/ScrollUIOverlay.tsx
@@ -262,8 +262,18 @@ export default function ScrollUIOverlay() {
     ) {
       // Passed carousel section, adjust scroll position
       adjustedScrollPos -= carouselSubSections;
-    } else if (!section.sticky && !section.carousel) {
+    } else if (
+      !section.sticky &&
+      !section.carousel &&
+      !section.cyberpunkSlider
+    ) {
       // Regular section
+      if (adjustedScrollPos >= i && adjustedScrollPos < i + 1) {
+        active = i;
+        break;
+      }
+    } else if (section.cyberpunkSlider) {
+      // Cyberpunk slider section
       if (adjustedScrollPos >= i && adjustedScrollPos < i + 1) {
         active = i;
         break;

--- a/src/components/ScrollUIOverlay.tsx
+++ b/src/components/ScrollUIOverlay.tsx
@@ -380,7 +380,7 @@ export default function ScrollUIOverlay() {
 
               {/* Cyberpunk Image Slider for Enterprise Command */}
               {sec.cyberpunkSlider && isActive && (
-                <div className="w-screen h-screen flex items-center justify-center">
+                <div className="fixed inset-0 z-30 flex items-center justify-center pointer-events-none">
                   <CyberpunkImageSlider />
                 </div>
               )}

--- a/src/components/ScrollUIOverlay.tsx
+++ b/src/components/ScrollUIOverlay.tsx
@@ -309,7 +309,8 @@ export default function ScrollUIOverlay() {
             ${sec.align === "left" ? "text-left ml-0 md:ml-16" : ""}
             ${sec.align === "right" ? "text-right mr-0 md:mr-16" : ""}
             ${sec.align === "center" ? "text-center mx-auto" : ""}
-            ${sec.fullScreenPricing ? "hidden" : ""}`}
+            ${sec.fullScreenPricing ? "hidden" : ""}
+            ${sec.cyberpunkSlider ? "hidden" : ""}`}
             >
               <h1 className="font-bold cyan-glow mb-4 text-4xl md:text-6xl">
                 {sec.title}
@@ -369,7 +370,7 @@ export default function ScrollUIOverlay() {
 
               {/* Cyberpunk Image Slider for Enterprise Command */}
               {sec.cyberpunkSlider && isActive && (
-                <div className="mb-6">
+                <div className="w-screen h-screen flex items-center justify-center">
                   <CyberpunkImageSlider />
                 </div>
               )}

--- a/src/components/ScrollUIOverlay.tsx
+++ b/src/components/ScrollUIOverlay.tsx
@@ -367,6 +367,13 @@ export default function ScrollUIOverlay() {
                 </div>
               )}
 
+              {/* Cyberpunk Image Slider for Enterprise Command */}
+              {sec.cyberpunkSlider && isActive && (
+                <div className="mb-6 -mx-8 -my-8">
+                  <CyberpunkImageSlider />
+                </div>
+              )}
+
               {/* Carousel Images for Enterprise Command */}
               {isCarouselSection && sec.carouselImages && (
                 <div className="mb-6 relative overflow-hidden rounded-xl">

--- a/src/components/ScrollUIOverlay.tsx
+++ b/src/components/ScrollUIOverlay.tsx
@@ -10,12 +10,6 @@ const sections = [
     align: "center",
   },
   {
-    title: "ScorpiusCore",
-    subtitle: "The Next-Gen Cyber Defense Engine",
-    desc: "A living, breathing core of wireframe intelligence and pulsing quantum energy. The heart of your war room.",
-    align: "center",
-  },
-  {
     title: "Quantum Threat Detection",
     subtitle: "See the Unseen",
     desc: "AI-powered, zero-latency threat recognition. Every anomaly, every shadow, instantly mapped and neutralized.",

--- a/src/components/ui/cyberpunk-image-slider.tsx
+++ b/src/components/ui/cyberpunk-image-slider.tsx
@@ -130,11 +130,11 @@ export const CyberpunkImageSlider = () => {
                   <img
                     src={image}
                     alt={`Cyber defense interface ${(index % images.length) + 1}`}
-                    className="w-full h-full object-cover"
+                    className="w-full h-full object-cover opacity-40"
                     loading="lazy"
                   />
                   {/* Cyber overlay */}
-                  <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-cyan-400/20"></div>
+                  <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-cyan-400/10"></div>
                   {/* Scanning line effect */}
                   <div className="scan-line"></div>
                   {/* Corner accents */}

--- a/src/components/ui/cyberpunk-image-slider.tsx
+++ b/src/components/ui/cyberpunk-image-slider.tsx
@@ -1,0 +1,157 @@
+"use client";
+import React from "react";
+
+export const CyberpunkImageSlider = () => {
+  // Cybersecurity and tech-themed images from Unsplash
+  const images = [
+    "https://images.unsplash.com/photo-1518495973542-4542c06a5843?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.1.0",
+    "https://images.unsplash.com/photo-1472396961693-142e6e269027?q=80&w=2152&auto=format&fit=crop&ixlib=rb-4.1.0",
+    "https://images.unsplash.com/photo-1505142468610-359e7d316be0?q=80&w=2126&auto=format&fit=crop&ixlib=rb-4.1.0",
+    "https://images.unsplash.com/photo-1482881497185-d4a9ddbe4151?q=80&w=1965&auto=format&fit=crop&ixlib=rb-4.1.0",
+    "https://images.unsplash.com/photo-1551288049-bebda4e38f71?w=800&h=600&fit=crop&crop=center",
+    "https://images.unsplash.com/photo-1558494949-ef010cbdcc31?w=800&h=600&fit=crop&crop=center",
+    "https://images.unsplash.com/photo-1460925895917-afdab827c52f?w=800&h=600&fit=crop&crop=center",
+    "https://images.unsplash.com/photo-1454165804606-c3d57bc86b40?w=800&h=600&fit=crop&crop=center",
+  ];
+
+  // Duplicate images for seamless loop
+  const duplicatedImages = [...images, ...images];
+
+  return (
+    <>
+      <style>{`
+        @keyframes cyber-scroll {
+          0% {
+            transform: translateX(0);
+          }
+          100% {
+            transform: translateX(-50%);
+          }
+        }
+
+        .cyber-infinite-scroll {
+          animation: cyber-scroll 25s linear infinite;
+        }
+
+        .cyber-scroll-container {
+          mask: linear-gradient(
+            90deg,
+            transparent 0%,
+            rgba(0, 212, 212, 0.3) 5%,
+            rgba(0, 212, 212, 1) 15%,
+            rgba(0, 212, 212, 1) 85%,
+            rgba(0, 212, 212, 0.3) 95%,
+            transparent 100%
+          );
+          -webkit-mask: linear-gradient(
+            90deg,
+            transparent 0%,
+            rgba(0, 212, 212, 0.3) 5%,
+            rgba(0, 212, 212, 1) 15%,
+            rgba(0, 212, 212, 1) 85%,
+            rgba(0, 212, 212, 0.3) 95%,
+            transparent 100%
+          );
+        }
+
+        .cyber-image-item {
+          transition: all 0.3s ease;
+          position: relative;
+        }
+
+        .cyber-image-item:hover {
+          transform: scale(1.05);
+          filter: brightness(1.2) saturate(1.3);
+        }
+
+        .cyber-image-item::before {
+          content: '';
+          position: absolute;
+          top: 0;
+          left: 0;
+          right: 0;
+          bottom: 0;
+          border: 2px solid transparent;
+          border-radius: 12px;
+          background: linear-gradient(45deg, #00d4d4, #008b8b, #004d4d, #00d4d4) border-box;
+          mask: linear-gradient(#fff 0 0) padding-box, linear-gradient(#fff 0 0);
+          mask-composite: xor;
+          -webkit-mask: linear-gradient(#fff 0 0) padding-box, linear-gradient(#fff 0 0);
+          -webkit-mask-composite: xor;
+          opacity: 0;
+          transition: opacity 0.3s ease;
+          z-index: 1;
+        }
+
+        .cyber-image-item:hover::before {
+          opacity: 0.8;
+        }
+
+        .scan-line {
+          position: absolute;
+          top: 0;
+          left: -100%;
+          width: 100%;
+          height: 2px;
+          background: linear-gradient(90deg, transparent, #00ffff, transparent);
+          animation: scan 3s linear infinite;
+        }
+
+        @keyframes scan {
+          0% { left: -100%; }
+          100% { left: 100%; }
+        }
+      `}</style>
+
+      <div className="w-full bg-war-room-abyss relative overflow-hidden py-16">
+        {/* Cyber grid background */}
+        <div className="absolute inset-0 opacity-10">
+          <div
+            className="absolute inset-0"
+            style={{
+              backgroundImage: `
+                   linear-gradient(rgba(0, 212, 212, 0.1) 1px, transparent 1px),
+                   linear-gradient(90deg, rgba(0, 212, 212, 0.1) 1px, transparent 1px)
+                 `,
+              backgroundSize: "50px 50px",
+            }}
+          ></div>
+        </div>
+
+        {/* Scrolling images container */}
+        <div className="relative z-10 w-full flex items-center justify-center">
+          <div className="cyber-scroll-container w-full">
+            <div className="cyber-infinite-scroll flex gap-8 w-max">
+              {duplicatedImages.map((image, index) => (
+                <div
+                  key={index}
+                  className="cyber-image-item flex-shrink-0 w-64 h-64 lg:w-80 lg:h-80 rounded-xl overflow-hidden relative"
+                >
+                  <img
+                    src={image}
+                    alt={`Cyber defense interface ${(index % images.length) + 1}`}
+                    className="w-full h-full object-cover"
+                    loading="lazy"
+                  />
+                  {/* Cyber overlay */}
+                  <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-cyan-400/20"></div>
+                  {/* Scanning line effect */}
+                  <div className="scan-line"></div>
+                  {/* Corner accents */}
+                  <div className="absolute top-2 left-2 w-4 h-4 border-l-2 border-t-2 border-cyan-400"></div>
+                  <div className="absolute top-2 right-2 w-4 h-4 border-r-2 border-t-2 border-cyan-400"></div>
+                  <div className="absolute bottom-2 left-2 w-4 h-4 border-l-2 border-b-2 border-cyan-400"></div>
+                  <div className="absolute bottom-2 right-2 w-4 h-4 border-r-2 border-b-2 border-cyan-400"></div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Cyber glow effects */}
+        <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-cyan-400 to-transparent opacity-50"></div>
+        <div className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-cyan-400 to-transparent opacity-50"></div>
+      </div>
+    </>
+  );
+};

--- a/src/components/ui/cyberpunk-image-slider.tsx
+++ b/src/components/ui/cyberpunk-image-slider.tsx
@@ -103,7 +103,7 @@ export const CyberpunkImageSlider = () => {
         }
       `}</style>
 
-      <div className="w-full bg-war-room-abyss relative overflow-hidden py-16">
+      <div className="w-screen bg-war-room-abyss relative overflow-hidden py-24 -mx-[50vw] left-1/2 right-1/2">
         {/* Cyber grid background */}
         <div className="absolute inset-0 opacity-10">
           <div
@@ -121,11 +121,11 @@ export const CyberpunkImageSlider = () => {
         {/* Scrolling images container */}
         <div className="relative z-10 w-full flex items-center justify-center">
           <div className="cyber-scroll-container w-full">
-            <div className="cyber-infinite-scroll flex gap-8 w-max">
+            <div className="cyber-infinite-scroll flex gap-12 w-max">
               {duplicatedImages.map((image, index) => (
                 <div
                   key={index}
-                  className="cyber-image-item flex-shrink-0 w-64 h-64 lg:w-80 lg:h-80 rounded-xl overflow-hidden relative"
+                  className="cyber-image-item flex-shrink-0 w-80 h-80 md:w-96 md:h-96 lg:w-[28rem] lg:h-[28rem] xl:w-[32rem] xl:h-[32rem] rounded-xl overflow-hidden relative"
                 >
                   <img
                     src={image}
@@ -138,10 +138,10 @@ export const CyberpunkImageSlider = () => {
                   {/* Scanning line effect */}
                   <div className="scan-line"></div>
                   {/* Corner accents */}
-                  <div className="absolute top-2 left-2 w-4 h-4 border-l-2 border-t-2 border-cyan-400"></div>
-                  <div className="absolute top-2 right-2 w-4 h-4 border-r-2 border-t-2 border-cyan-400"></div>
-                  <div className="absolute bottom-2 left-2 w-4 h-4 border-l-2 border-b-2 border-cyan-400"></div>
-                  <div className="absolute bottom-2 right-2 w-4 h-4 border-r-2 border-b-2 border-cyan-400"></div>
+                  <div className="absolute top-3 left-3 w-6 h-6 border-l-2 border-t-2 border-cyan-400"></div>
+                  <div className="absolute top-3 right-3 w-6 h-6 border-r-2 border-t-2 border-cyan-400"></div>
+                  <div className="absolute bottom-3 left-3 w-6 h-6 border-l-2 border-b-2 border-cyan-400"></div>
+                  <div className="absolute bottom-3 right-3 w-6 h-6 border-r-2 border-b-2 border-cyan-400"></div>
                 </div>
               ))}
             </div>

--- a/src/components/ui/demo.tsx
+++ b/src/components/ui/demo.tsx
@@ -1,0 +1,10 @@
+// This is file with demos of your component
+// Each export is one usecase for your component
+
+import { Component } from "@/components/ui/image-auto-slider";
+
+const DemoOne = () => {
+  return <Component />;
+};
+
+export { DemoOne };

--- a/src/components/ui/image-auto-slider.tsx
+++ b/src/components/ui/image-auto-slider.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+
+export const Component = () => {
+  // Images for the infinite scroll - using Unsplash URLs
+  const images = [
+    "https://images.unsplash.com/photo-1518495973542-4542c06a5843?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    "https://images.unsplash.com/photo-1472396961693-142e6e269027?q=80&w=2152&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    "https://images.unsplash.com/photo-1505142468610-359e7d316be0?q=80&w=2126&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    "https://images.unsplash.com/photo-1482881497185-d4a9ddbe4151?q=80&w=1965&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    "https://plus.unsplash.com/premium_photo-1673264933212-d78737f38e48?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    "https://plus.unsplash.com/premium_photo-1711434824963-ca894373272e?q=80&w=2030&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    "https://plus.unsplash.com/premium_photo-1675705721263-0bbeec261c49?q=80&w=1940&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    "https://images.unsplash.com/photo-1524799526615-766a9833dec0?q=80&w=1935&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  ];
+
+  // Duplicate images for seamless loop
+  const duplicatedImages = [...images, ...images];
+
+  return (
+    <>
+      <style>{`
+        html, body {
+          margin: 0;
+          padding: 0;
+          overflow-x: hidden;
+          font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        }
+
+        @keyframes scroll-right {
+          0% {
+            transform: translateX(0);
+          }
+          100% {
+            transform: translateX(-50%);
+          }
+        }
+
+        .infinite-scroll {
+          animation: scroll-right 20s linear infinite;
+        }
+
+        .scroll-container {
+          mask: linear-gradient(
+            90deg,
+            transparent 0%,
+            black 10%,
+            black 90%,
+            transparent 100%
+          );
+          -webkit-mask: linear-gradient(
+            90deg,
+            transparent 0%,
+            black 10%,
+            black 90%,
+            transparent 100%
+          );
+        }
+
+        .image-item {
+          transition: transform 0.3s ease, filter 0.3s ease;
+        }
+
+        .image-item:hover {
+          transform: scale(1.05);
+          filter: brightness(1.1);
+        }
+      `}</style>
+
+      <div className="w-full min-h-screen bg-black relative overflow-hidden flex items-center justify-center">
+        {/* Background gradient */}
+        <div className="absolute inset-0 bg-gradient-to-b from-black via-black/90 to-black z-0" />
+
+        {/* Scrolling images container */}
+        <div className="relative z-10 w-full flex items-center justify-center py-8">
+          <div className="scroll-container w-full max-w-6xl">
+            <div className="infinite-scroll flex gap-6 w-max">
+              {duplicatedImages.map((image, index) => (
+                <div
+                  key={index}
+                  className="image-item flex-shrink-0 w-48 h-48 md:w-64 md:h-64 lg:w-80 lg:h-80 rounded-xl overflow-hidden shadow-2xl"
+                >
+                  <img
+                    src={image}
+                    alt={`Gallery image ${(index % images.length) + 1}`}
+                    className="w-full h-full object-cover"
+                    loading="lazy"
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Bottom gradient overlay */}
+        <div className="absolute bottom-0 left-0 right-0 h-24 bg-gradient-to-t from-black to-transparent z-20" />
+      </div>
+    </>
+  );
+};


### PR DESCRIPTION
This pull request adds new components and modifies the page structure:

**Main page changes:**
- Import and add PricingTiers component
- Wrap main content in React fragment to include pricing section
- Move main content structure inside fragment wrapper

**ScrollUIOverlay updates:**
- Import CyberpunkImageSlider component
- Remove "ScorpiusCore" section from sections array
- Replace carousel functionality with cyberpunkSlider for Enterprise Command section
- Remove carouselImages array and carousel logic
- Add cyberpunkSlider detection and rendering logic
- Update section filtering to handle cyberpunkSlider sections

**New components added:**
- CyberpunkImageSlider: Full-featured cyberpunk-themed image slider with animations, hover effects, and cyber styling
- Component: Basic auto-scrolling image gallery component
- Demo: Demo file for image slider component

The changes restructure the page to include pricing at the end and replace the carousel with a cyberpunk-styled image slider for better visual consistency.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c7953a7be18a4ecd9beaa8539bec058d/pulse-verse)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c7953a7be18a4ecd9beaa8539bec058d</projectId>-->
<!--<branchName>pulse-verse</branchName>-->